### PR TITLE
 允许自定义 webpack 配置能拿到 opts

### DIFF
--- a/packages/dn-middleware-webpack/lib/generate.js
+++ b/packages/dn-middleware-webpack/lib/generate.js
@@ -340,6 +340,7 @@ async function handleUMD(wpConfig, opts) {
 //配置生成函数
 async function generate(ctx, opts) {
   opts = await handleOpts(opts);
+  ctx.opts = opts;
   let wpConfig = {
     context: ctx.cwd,
     entry: {},


### PR DESCRIPTION
当用户需要扩展 webpack 配置时，能够在 webpack.config.js 中拿到 opts 是有必要的