### PR TITLE
webpack 中间件增加 'webpack.compiler' 事件

### DIFF
--- a/packages/dn-middleware-webpack/lib/index.js
+++ b/packages/dn-middleware-webpack/lib/index.js
@@ -98,6 +98,12 @@ module.exports = function (opts) {
 
     //build
     let compiler = webpack(config);
+
+    // register 'webpack.compiler' event.
+    // support webpackDevServer (or other) middleware(s)
+    // to use webpack compiler instance
+    this.emit('webpack.compiler', compiler);
+
     if (opts.watch) {
       compiler.watch(opts.watchOpts, (err, stats) => {
         if (err) return this.console.error(err);


### PR DESCRIPTION
feat: add  event to webpack middleware；

其主要目的是在 `webpack-dev-server` 中间件中能够拿到在 `webpack` 中间件中实例化的 `compiler`。