### PR TITLE
修复中心服务pipe.yml前置规则执行顺序问题

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -86,6 +86,7 @@ class Context extends EventEmitter {
     pipe.before = pipe.before || [];
     pipe.after = pipe.after || [];
     let beforeList = pipe.before[command] || [];
+    beforeList.reverse();
     beforeList.forEach(item => {
       if (list.some(i => i.name == item.name && !item.force)) return;
       list.unshift(item);


### PR DESCRIPTION
目前配置中心服务前置规则
```
# 前置规则，会合并到工程本地配置的前边
before:
  dev:
    - name: lint
    - name: clean
```
实际执行结果为 `clean -> lint`
