### PR TITLE
fix: tslint 中间件命令行参数增加引号转义

### DIFF
--- a/packages/dn-middleware-tslint/lib/index.js
+++ b/packages/dn-middleware-tslint/lib/index.js
@@ -28,7 +28,7 @@ module.exports = function (opts) {
 
     await this.utils.exec([
       cmd, '--config', rulesFile, '--project', tsconfigFile,
-      '--exclude', '**/*.d.ts', '--format', 'stylish', '--fix'
+      '--exclude', '\'**/*.d.ts\'', '--format', 'stylish', '--fix'
     ].join(' '));
 
     next();


### PR DESCRIPTION
fix: tslint cmd use strict string as param