### PR TITLE
middleware的安装目录由当前项目移动至全局仓库，提升初始化速度

### DIFF
--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -6,7 +6,9 @@
 const console = require('../common/console');
 const store = require('../store');
 const mod = require('../mod');
-
+const Context = require('../context');
+const middleware = require('../middleware');
+const _ = require('lodash');
 module.exports = async function () {
   console.info('Updating...');
   await Promise.all([
@@ -15,6 +17,24 @@ module.exports = async function () {
     store.clean('modules'),
     mod.clean()
   ]);
+  const context = new Context(this);
+  const { pipe: config } = await context.loadLocalConfigs();
+  let list = [];
+  for (const key in config) {
+    if (config.hasOwnProperty(key)) {
+      const element = config[key];
+      list = list.concat(element);
+    }
+  }
+  console.info('Updating middlewares...');
+  let filterList = list.filter(item => !item.location);
+  filterList = _.uniqBy(filterList, 'name');
+  for (const iterator of filterList) {
+    await middleware.require(iterator.name, this.cwd, {
+      update: true
+    });
+  }
+  console.info('Updating middlewares Done');
   await mod.install();
   console.info('Done');
 };

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -2,7 +2,7 @@
  * Copyright (c) 2016-present Alibaba Group Holding Limited
  * @author Houfeng <admin@xhou.net>
  */
-
+const exec = require('./common/exec');
 const configs = require('./configs');
 const utils = require('ntils');
 const path = require('path');
@@ -10,6 +10,8 @@ const mod = require('./mod');
 const debug = require('debug')('middleware');
 const fs = require('fs');
 const pkgname = require('./common/pkgname');
+
+let GLOBAL_MODULE_PATH = '';
 
 exports.list = async function () {
   const middlewares = [];
@@ -63,8 +65,14 @@ exports.getDocUrl = async function (name) {
   return mod.getDocUrl(name, prefix);
 };
 
-exports.require = async function (name, cwd) {
+exports.require = async function (name, cwd, params = {}) {
   cwd = cwd || process.cwd();
+  const npmBin = await configs.getRc('npm') || 'npm';
+  if (!GLOBAL_MODULE_PATH) {
+    let result = await exec.withResult(`${npmBin} root -g`);
+    GLOBAL_MODULE_PATH = result.replace(/\/node_modules[.\n]*/g, '');
+  }
+  cwd = GLOBAL_MODULE_PATH;
   debug('require', name, cwd);
   const nameInfo = await this.getInfo(name);
   let mdModule;
@@ -76,10 +84,14 @@ exports.require = async function (name, cwd) {
     const packagePath = path
       .normalize(`${cwd}/node_modules/${nameInfo.fullName}`);
     debug('packagePath', packagePath);
-    if (!fs.existsSync(packagePath)) {
-      const prefix = await configs.getRc('middlewarePrefix');
+    const prefix = await configs.getRc('middlewarePrefix');
+    if (params.update) {
+      await mod.update(nameInfo.fullNameAndVersion, {
+        flag: { 'g': true, 'force': true }, prefix: prefix
+      });
+    } else if (!fs.existsSync(packagePath)) {
       await mod.install(nameInfo.fullNameAndVersion, {
-        flag: { 'save-dev': true }, prefix: prefix
+        flag: { 'g': true }, prefix: prefix
       });
     }
     mdModule = require(packagePath);

--- a/lib/mod.js
+++ b/lib/mod.js
@@ -41,6 +41,20 @@ exports.exec = async function (cmd, opts) {
   await exec(script, { cwd: opts.cwd });
 };
 
+exports.update = async function (name, opts) {
+  opts = Object.assign({}, opts);
+  opts.flag = opts.flag || {};
+  const pkgFile = path.normalize(`${process.cwd()}/package.json`);
+  if (!opts.flag.global && !opts.flag.g && !fs.existsSync(pkgFile)) {
+    return;
+  }
+  console.info(`Updating '${name || 'dependencies'}' ...`);
+  const nameInfo = pkgname(name, opts.prefix);
+  delete opts.prefix;
+  await this.exec(`i ${nameInfo.fullNameAndVersion || ''}`, opts);
+  console.info('Done');
+};
+
 exports.install = async function (name, opts) {
   opts = Object.assign({}, opts);
   opts.flag = opts.flag || {};


### PR DESCRIPTION
## 改造思路

#### init阶段

改造方案：改造加载中间件阶段，由当前工程目录下安装，写入devDenpendcies的流程改造为安装到全局目录下，这样其他模块再次初始化时，会直接复用这部分的全局模块。

#### update阶段

改造方案：由于将中间件的安装挪到了全局目录里，所以在update阶段，需要增加一个对中间件更新的逻辑：获取到当前项目里包含的所有中间件，在全局环境下重新执行一遍安装过程（使用`npm install --force packageName`）。