### PR TITLE
fix: 优先本地node_modules/.bin

### DIFF
--- a/packages/dn-middleware-shell/lib/index.js
+++ b/packages/dn-middleware-shell/lib/index.js
@@ -11,7 +11,7 @@ module.exports = function (opts) {
     try {
       const env = Object.assign({}, process.env);
       const bin = path.normalize(`${this.cwd}/node_modules/.bin`);
-      env.PATH = `${env.PATH}${isWin ? ';' : ':'}${bin}`;
+      env.PATH = `${bin}${isWin ? ';' : ':'}${env.PATH}`;
       const pending = this.utils.exec(script.join(os.EOL), { env });
       if (!opts.async) await pending;
       this.console.info('Done');


### PR DESCRIPTION
把项目本地的node_modules/.bin放到PATH的最前面，确保优先使用本地安装的命令。

例如：
本地安装@babel/cli@7，全局安装babel-cli@6
```yml
build:
  - name: shell
     script:
       - babel src --out-dir lib
```
之前执行dn run build时，实际执行的babel为全局安装的版本
修改之后，再执行dn run build时，实际执行的会是本地安装的babel
