### PR TITLE
feat: add `disableAutoReactRequire` option to exclude `babel-plugin-react-require` plugin

### DIFF
--- a/packages/dn-middleware-babel/CHANGELOG.md
+++ b/packages/dn-middleware-babel/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## 1.4.0 (2020-11-16)
+
+### Features
+
+- Support `disableAutoReactRequire` to exclude `babel-plugin-react-require` plugin.
+
+### Breaking Changes (maybe)
+
+- If `jsxRuntime` is `"automatic"` and using React 17.0.0+/16.14.0+/15.7.0+/0.14.10+, `disableAutoReactRequire` is set to `true` by default.
+
 ## 1.3.0 (2020-11-11)
 
 ### Features

--- a/packages/dn-middleware-babel/README.md
+++ b/packages/dn-middleware-babel/README.md
@@ -120,6 +120,15 @@ _说明：当配置为 `"browser"` 时，可通过 `.browserslistrc` 指定目�
 
 配置 `@babel/preset-react` 的 `runtime` 选项
 
+### `disableAutoReactRequire`
+
+类型：`boolean`<br>
+默认值：
+
+配置是否排除 `babel-plugin-react-require`。默认情况下不会排除，但如果 `jsxRuntime` 设置为 `"automatic"` 并且使用了支持新 JSX Runtime 的 React 版本，则默认排除
+
+配置 `@babel/preset-react` 的 `runtime` 选项
+
 ### `extraPresets`
 
 类型：`any[]`<br>

--- a/packages/dn-middleware-babel/package-lock.json
+++ b/packages/dn-middleware-babel/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dn-middleware-babel",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/dn-middleware-babel/package.json
+++ b/packages/dn-middleware-babel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dn-middleware-babel",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Transform code with babel",
   "keywords": [
     "dawn",

--- a/packages/dn-middleware-babel/src/babel.ts
+++ b/packages/dn-middleware-babel/src/babel.ts
@@ -28,6 +28,7 @@ export const run = async (
     runtimeHelpers,
     corejs,
     jsxRuntime,
+    disableAutoReactRequire,
     extraPresets = [],
     extraPlugins = [],
     nodeVersion,
@@ -49,6 +50,7 @@ export const run = async (
     runtimeHelpers,
     corejs,
     jsxRuntime,
+    disableAutoReactRequire,
     nodeVersion,
     lazy,
   });

--- a/packages/dn-middleware-babel/src/getBabelConfig.ts
+++ b/packages/dn-middleware-babel/src/getBabelConfig.ts
@@ -3,7 +3,18 @@ import { IGetBabelConfigOpts } from "./types";
 import { hasJsxRuntime } from "./utils";
 
 export const getBabelConfig = (opts: IGetBabelConfigOpts): Pick<TransformOptions, "presets" | "plugins"> => {
-  const { env, target, typescript, type, runtimeHelpers, corejs, jsxRuntime, nodeVersion, lazy } = opts;
+  const {
+    env,
+    target,
+    typescript,
+    type,
+    runtimeHelpers,
+    corejs,
+    jsxRuntime,
+    disableAutoReactRequire,
+    nodeVersion,
+    lazy,
+  } = opts;
   const isBrowser = target === "browser";
   const targets = isBrowser ? undefined : { node: nodeVersion || "10" };
 
@@ -40,7 +51,9 @@ export const getBabelConfig = (opts: IGetBabelConfigOpts): Pick<TransformOptions
             ],
           ]
         : []),
-      require.resolve("babel-plugin-react-require"),
+      ...(disableAutoReactRequire !== false || (jsxRuntime === "automatic" && hasJsxRuntime())
+        ? [require.resolve("babel-plugin-react-require")]
+        : []),
       require.resolve("@babel/plugin-syntax-dynamic-import"),
       require.resolve("@babel/plugin-proposal-export-default-from"),
       require.resolve("@babel/plugin-proposal-export-namespace-from"),

--- a/packages/dn-middleware-babel/src/getBabelConfig.ts
+++ b/packages/dn-middleware-babel/src/getBabelConfig.ts
@@ -51,9 +51,9 @@ export const getBabelConfig = (opts: IGetBabelConfigOpts): Pick<TransformOptions
             ],
           ]
         : []),
-      ...(disableAutoReactRequire !== false || (jsxRuntime === "automatic" && hasJsxRuntime())
-        ? [require.resolve("babel-plugin-react-require")]
-        : []),
+      ...(disableAutoReactRequire !== true || (jsxRuntime === "automatic" && hasJsxRuntime())
+        ? []
+        : [require.resolve("babel-plugin-react-require")]),
       require.resolve("@babel/plugin-syntax-dynamic-import"),
       require.resolve("@babel/plugin-proposal-export-default-from"),
       require.resolve("@babel/plugin-proposal-export-namespace-from"),

--- a/packages/dn-middleware-babel/src/types.ts
+++ b/packages/dn-middleware-babel/src/types.ts
@@ -15,6 +15,7 @@ export interface IOpts {
   runtimeHelpers?: boolean | string;
   corejs?: false | 2 | 3 | { version: 2 | 3; proposals: boolean };
   jsxRuntime?: "automatic" | "classic";
+  disableAutoReactRequire?: boolean;
   extraPresets?: any[];
   extraPlugins?: any[];
   nodeVersion?: string | "current" | true;
@@ -30,6 +31,7 @@ export interface IGetBabelConfigOpts {
   typescript?: boolean;
   runtimeHelpers?: boolean | string;
   jsxRuntime?: "automatic" | "classic";
+  disableAutoReactRequire?: boolean;
   corejs?: false | 2 | 3 | { version: 2 | 3; proposals: boolean };
   nodeVersion?: number;
   lazy?: boolean;


### PR DESCRIPTION
- `disableAutoReactRequire` is `true` by default if `jsxRuntime` is `automatic` and React has new JSX Runtime