### PR TITLE
fix: should transfer type to string or buffer when writefile

### DIFF
--- a/lib/common/writefile.js
+++ b/lib/common/writefile.js
@@ -4,10 +4,14 @@
  */
 
 const fs = require('fs');
+const Buffer = require('buffer').Buffer;
 
-module.exports = async function (filename, content) {
+module.exports = async function(filename, content) {
   return new Promise((resolve, reject) => {
-    fs.writeFile(filename, String(content), err => {
+    if (typeof content !== 'string' && !Buffer.isBuffer(content)) {
+      content = String(content);
+    }
+    fs.writeFile(filename, content, (err) => {
       if (err) return reject(err);
       resolve(filename);
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dawn",
-  "version": "1.9.1",
+  "version": "1.9.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dawn",
-  "version": "1.9.1",
+  "version": "1.9.3",
   "description": "dawn cli",
   "main": "./lib/index.js",
   "bin": {


### PR DESCRIPTION
Test success.

Node version from `v10.20.1` to `v14.15.4`, both `Binary file` and `Text file`.