### PR TITLE
Fix babel preset loose config warnings.

### DIFF
--- a/packages/babel-preset-dawn/CHANGELOG.md
+++ b/packages/babel-preset-dawn/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.1.4](https://github.com/alibaba/dawn/compare/@dawnjs/babel-preset-dawn@2.1.3...@dawnjs/babel-preset-dawn@2.1.4) (2021-05-26)
+
+
+### Bug Fixes
+
+* **babel-preset-dawn:** remove useless plugin ([767f92d](https://github.com/alibaba/dawn/commit/767f92d9b01222bbbe256eff0589d77214fe7ebe))
+
+
+
+
+
 ## [2.1.3](https://github.com/alibaba/dawn/compare/@dawnjs/babel-preset-dawn@2.1.2...@dawnjs/babel-preset-dawn@2.1.3) (2021-05-26)
 
 

--- a/packages/babel-preset-dawn/CHANGELOG.md
+++ b/packages/babel-preset-dawn/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.1.3](https://github.com/alibaba/dawn/compare/@dawnjs/babel-preset-dawn@2.1.2...@dawnjs/babel-preset-dawn@2.1.3) (2021-05-26)
+
+
+### Bug Fixes
+
+* **babel-preset-dawn:** clear babel warnings away ([6f09451](https://github.com/alibaba/dawn/commit/6f094514a42c07ae047ddad498e500e2d93c53a3))
+
+
+
+
+
 ## [2.1.2](https://github.com/alibaba/dawn/compare/@dawnjs/babel-preset-dawn@2.1.1...@dawnjs/babel-preset-dawn@2.1.2) (2021-04-14)
 
 

--- a/packages/babel-preset-dawn/package.json
+++ b/packages/babel-preset-dawn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dawnjs/babel-preset-dawn",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Basic babel preset",
   "keywords": [
     "dawn",

--- a/packages/babel-preset-dawn/package.json
+++ b/packages/babel-preset-dawn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dawnjs/babel-preset-dawn",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Basic babel preset",
   "keywords": [
     "dawn",

--- a/packages/babel-preset-dawn/src/index.ts
+++ b/packages/babel-preset-dawn/src/index.ts
@@ -39,9 +39,6 @@ export default (ctx: any, opts: IOpts = {}) => {
       // should be placed before @babel/plugin-proposal-decorators.
       opts.typescript && "babel-plugin-transform-typescript-metadata",
       ["@babel/plugin-proposal-decorators", { legacy: true }],
-      // https://babeljs.io/docs/en/babel-plugin-proposal-class-properties#loose
-      // When `loose` true, class properties are compiled to use an assignment expression instead of Object.defineProperty.
-      ["@babel/plugin-proposal-class-properties", { setPublicClassFields: true }],
       opts.transformRuntime && ["@babel/plugin-transform-runtime", toObject(opts.transformRuntime)],
       "@babel/plugin-proposal-function-bind",
       "@babel/plugin-proposal-logical-assignment-operators",

--- a/packages/babel-preset-dawn/src/index.ts
+++ b/packages/babel-preset-dawn/src/index.ts
@@ -39,7 +39,9 @@ export default (ctx: any, opts: IOpts = {}) => {
       // should be placed before @babel/plugin-proposal-decorators.
       opts.typescript && "babel-plugin-transform-typescript-metadata",
       ["@babel/plugin-proposal-decorators", { legacy: true }],
-      ["@babel/plugin-proposal-class-properties", { loose: true }],
+      // https://babeljs.io/docs/en/babel-plugin-proposal-class-properties#loose
+      // When `loose` true, class properties are compiled to use an assignment expression instead of Object.defineProperty.
+      ["@babel/plugin-proposal-class-properties", { setPublicClassFields: true }],
       opts.transformRuntime && ["@babel/plugin-transform-runtime", toObject(opts.transformRuntime)],
       "@babel/plugin-proposal-function-bind",
       "@babel/plugin-proposal-logical-assignment-operators",

--- a/packages/middleware-babel/CHANGELOG.md
+++ b/packages/middleware-babel/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.6](https://github.com/alibaba/dawn/compare/@dawnjs/dn-middleware-babel@2.0.5...@dawnjs/dn-middleware-babel@2.0.6) (2021-05-26)
+
+**Note:** Version bump only for package @dawnjs/dn-middleware-babel
+
+
+
+
+
 ## [2.0.5](https://github.com/alibaba/dawn/compare/@dawnjs/dn-middleware-babel@2.0.4...@dawnjs/dn-middleware-babel@2.0.5) (2021-05-26)
 
 **Note:** Version bump only for package @dawnjs/dn-middleware-babel

--- a/packages/middleware-babel/CHANGELOG.md
+++ b/packages/middleware-babel/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.5](https://github.com/alibaba/dawn/compare/@dawnjs/dn-middleware-babel@2.0.4...@dawnjs/dn-middleware-babel@2.0.5) (2021-05-26)
+
+**Note:** Version bump only for package @dawnjs/dn-middleware-babel
+
+
+
+
+
 ## [2.0.4](https://github.com/alibaba/dawn/compare/@dawnjs/dn-middleware-babel@2.0.3...@dawnjs/dn-middleware-babel@2.0.4) (2021-04-14)
 
 **Note:** Version bump only for package @dawnjs/dn-middleware-babel

--- a/packages/middleware-babel/package.json
+++ b/packages/middleware-babel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dawnjs/dn-middleware-babel",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Transform code with babel",
   "keywords": [
     "dawn",
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.12.3",
-    "@dawnjs/babel-preset-dawn": "^2.1.3",
+    "@dawnjs/babel-preset-dawn": "^2.1.4",
     "chokidar": "^3.5.1",
     "gulp-if": "^3.0.0",
     "gulp-typescript": "^5.0.1",

--- a/packages/middleware-babel/package.json
+++ b/packages/middleware-babel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dawnjs/dn-middleware-babel",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Transform code with babel",
   "keywords": [
     "dawn",
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.12.3",
-    "@dawnjs/babel-preset-dawn": "^2.1.2",
+    "@dawnjs/babel-preset-dawn": "^2.1.3",
     "chokidar": "^3.5.1",
     "gulp-if": "^3.0.0",
     "gulp-typescript": "^5.0.1",

--- a/packages/middleware-jest/CHANGELOG.md
+++ b/packages/middleware-jest/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.1.5](https://github.com/alibaba/dawn/compare/@dawnjs/dn-middleware-jest@2.1.4...@dawnjs/dn-middleware-jest@2.1.5) (2021-05-26)
+
+**Note:** Version bump only for package @dawnjs/dn-middleware-jest
+
+
+
+
+
 ## [2.1.4](https://github.com/alibaba/dawn/compare/@dawnjs/dn-middleware-jest@2.1.3...@dawnjs/dn-middleware-jest@2.1.4) (2021-05-26)
 
 **Note:** Version bump only for package @dawnjs/dn-middleware-jest

--- a/packages/middleware-jest/CHANGELOG.md
+++ b/packages/middleware-jest/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.1.4](https://github.com/alibaba/dawn/compare/@dawnjs/dn-middleware-jest@2.1.3...@dawnjs/dn-middleware-jest@2.1.4) (2021-05-26)
+
+**Note:** Version bump only for package @dawnjs/dn-middleware-jest
+
+
+
+
+
 ## [2.1.3](https://github.com/alibaba/dawn/compare/@dawnjs/dn-middleware-jest@2.1.2...@dawnjs/dn-middleware-jest@2.1.3) (2021-04-14)
 
 **Note:** Version bump only for package @dawnjs/dn-middleware-jest

--- a/packages/middleware-jest/package.json
+++ b/packages/middleware-jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dawnjs/dn-middleware-jest",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "Jest middleware for dawn project's unit-test.",
   "main": "./lib/index.js",
   "scripts": {
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.13.15",
-    "@dawnjs/babel-preset-dawn": "^2.1.3",
+    "@dawnjs/babel-preset-dawn": "^2.1.4",
     "babel-jest": "^26.6.3",
     "core-js": "^3.9.1",
     "jest": "^26.6.3",

--- a/packages/middleware-jest/package.json
+++ b/packages/middleware-jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dawnjs/dn-middleware-jest",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Jest middleware for dawn project's unit-test.",
   "main": "./lib/index.js",
   "scripts": {
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.13.15",
-    "@dawnjs/babel-preset-dawn": "^2.1.2",
+    "@dawnjs/babel-preset-dawn": "^2.1.3",
     "babel-jest": "^26.6.3",
     "core-js": "^3.9.1",
     "jest": "^26.6.3",

--- a/packages/middleware-rollup/CHANGELOG.md
+++ b/packages/middleware-rollup/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.7.2](https://github.com/alibaba/dawn/compare/@dawnjs/dn-middleware-rollup@1.7.1...@dawnjs/dn-middleware-rollup@1.7.2) (2021-05-26)
+
+**Note:** Version bump only for package @dawnjs/dn-middleware-rollup
+
+
+
+
+
 ## [1.7.1](https://github.com/alibaba/dawn/compare/@dawnjs/dn-middleware-rollup@1.7.0...@dawnjs/dn-middleware-rollup@1.7.1) (2021-04-14)
 
 

--- a/packages/middleware-rollup/CHANGELOG.md
+++ b/packages/middleware-rollup/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.7.3](https://github.com/alibaba/dawn/compare/@dawnjs/dn-middleware-rollup@1.7.2...@dawnjs/dn-middleware-rollup@1.7.3) (2021-05-26)
+
+**Note:** Version bump only for package @dawnjs/dn-middleware-rollup
+
+
+
+
+
 ## [1.7.2](https://github.com/alibaba/dawn/compare/@dawnjs/dn-middleware-rollup@1.7.1...@dawnjs/dn-middleware-rollup@1.7.2) (2021-05-26)
 
 **Note:** Version bump only for package @dawnjs/dn-middleware-rollup

--- a/packages/middleware-rollup/package.json
+++ b/packages/middleware-rollup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dawnjs/dn-middleware-rollup",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Dawn middleware to bundle assets with rollup",
   "keywords": [
     "dawn",
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.13.15",
-    "@dawnjs/babel-preset-dawn": "^2.1.3",
+    "@dawnjs/babel-preset-dawn": "^2.1.4",
     "@rollup/plugin-alias": "^3.1.2",
     "@rollup/plugin-babel": "^5.3.0",
     "@rollup/plugin-commonjs": "^18.0.0",

--- a/packages/middleware-rollup/package.json
+++ b/packages/middleware-rollup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dawnjs/dn-middleware-rollup",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Dawn middleware to bundle assets with rollup",
   "keywords": [
     "dawn",
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.13.15",
-    "@dawnjs/babel-preset-dawn": "^2.1.2",
+    "@dawnjs/babel-preset-dawn": "^2.1.3",
     "@rollup/plugin-alias": "^3.1.2",
     "@rollup/plugin-babel": "^5.3.0",
     "@rollup/plugin-commonjs": "^18.0.0",

--- a/packages/middleware-webpack/CHANGELOG.md
+++ b/packages/middleware-webpack/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.1.37](https://github.com/alibaba/dawn/compare/@dawnjs/dn-middleware-webpack@1.1.36...@dawnjs/dn-middleware-webpack@1.1.37) (2021-05-26)
+
+**Note:** Version bump only for package @dawnjs/dn-middleware-webpack
+
+
+
+
+
 ## [1.1.36](https://github.com/alibaba/dawn/compare/@dawnjs/dn-middleware-webpack@1.1.35...@dawnjs/dn-middleware-webpack@1.1.36) (2021-05-26)
 
 **Note:** Version bump only for package @dawnjs/dn-middleware-webpack

--- a/packages/middleware-webpack/CHANGELOG.md
+++ b/packages/middleware-webpack/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.1.36](https://github.com/alibaba/dawn/compare/@dawnjs/dn-middleware-webpack@1.1.35...@dawnjs/dn-middleware-webpack@1.1.36) (2021-05-26)
+
+**Note:** Version bump only for package @dawnjs/dn-middleware-webpack
+
+
+
+
+
 ## 1.1.35 (2021-05-24)
 
 **Note:** Version bump only for package @dawnjs/dn-middleware-webpack

--- a/packages/middleware-webpack/package.json
+++ b/packages/middleware-webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dawnjs/dn-middleware-webpack",
-  "version": "1.1.35",
+  "version": "1.1.36",
   "description": "A middleware to bundle assets with webpack5 in dawn pipeline",
   "keywords": [
     "dawn",
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.14.0",
-    "@dawnjs/babel-preset-dawn": "^2.1.2",
+    "@dawnjs/babel-preset-dawn": "^2.1.3",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.0-beta.7",
     "@swc/core": "^1.2.57",
     "babel-loader": "^8.2.2",

--- a/packages/middleware-webpack/package.json
+++ b/packages/middleware-webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dawnjs/dn-middleware-webpack",
-  "version": "1.1.36",
+  "version": "1.1.37",
   "description": "A middleware to bundle assets with webpack5 in dawn pipeline",
   "keywords": [
     "dawn",
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.14.0",
-    "@dawnjs/babel-preset-dawn": "^2.1.3",
+    "@dawnjs/babel-preset-dawn": "^2.1.4",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.0-beta.7",
     "@swc/core": "^1.2.57",
     "babel-loader": "^8.2.2",


### PR DESCRIPTION
```
Successfully published:
 - @dawnjs/babel-preset-dawn@2.1.4
 - @dawnjs/dn-middleware-babel@2.0.6
 - @dawnjs/dn-middleware-jest@2.1.5
 - @dawnjs/dn-middleware-rollup@1.7.3
 - @dawnjs/dn-middleware-webpack@1.1.37
```