### PR TITLE
fix(@dawnjs/dn-middleware-webpack): set publicPath to "/" in development mode

### DIFF
--- a/packages/middleware-webpack/src/config/configModule.ts
+++ b/packages/middleware-webpack/src/config/configModule.ts
@@ -394,7 +394,7 @@ export default async (config: Config, options: INormalizedOpts) => {
             if (typeof customOptions === "function") {
               customOptions = customOptions(loaderContext);
             }
-            return { fiber: Fiber, ...customOptions };
+            return { fiber: Fiber, quietDeps: true, ...customOptions };
           },
         },
       },

--- a/packages/middleware-webpack/src/config/configOutput.ts
+++ b/packages/middleware-webpack/src/config/configOutput.ts
@@ -7,7 +7,7 @@ export default async (config: Config, options: INormalizedOpts) => {
     .filename(path.join(options.folders.script, "[name].js"))
     .chunkFilename(path.join(options.folders.script, "[name].[chunkhash:8].chunk.js"))
     .set("assetModuleFilename", path.join(options.folders.media, "[name].[contenthash:8][ext]")) // TODO: replace after webpack-chain support webpack5
-    .publicPath(options.publicPath)
+    .publicPath(options.publicPath ?? (options.env === "development" ? "/" : undefined))
     .globalObject("this")
     .merge(options.output)
     .path(path.resolve(options.cwd, options.output.path));

--- a/packages/middleware-webpack/src/config/configOutput.ts
+++ b/packages/middleware-webpack/src/config/configOutput.ts
@@ -8,7 +8,6 @@ export default async (config: Config, options: INormalizedOpts) => {
     .chunkFilename(path.join(options.folders.script, "[name].[chunkhash:8].chunk.js"))
     .set("assetModuleFilename", path.join(options.folders.media, "[name].[contenthash:8][ext]")) // TODO: replace after webpack-chain support webpack5
     .publicPath(options.publicPath ?? (options.env === "development" ? "/" : undefined))
-    .globalObject("this")
     .merge(options.output)
     .path(path.resolve(options.cwd, options.output.path));
 };

--- a/packages/middleware-webpack/src/opts.ts
+++ b/packages/middleware-webpack/src/opts.ts
@@ -74,7 +74,7 @@ export const normalizeOpts = (opts: Partial<IOpts>, ctx: Context): INormalizedOp
       ...opts.folders,
     },
     babel: {
-      jsxRuntime: opts.jsxRuntime,
+      jsxRuntime: opts.jsxRuntime ?? true,
       runtimeHelpers: true,
       corejs: 3,
       ...opts.babel,


### PR DESCRIPTION
- Default set `output.publicPath` to `"/"` in development mode
- Default set `sassLoader.sassOptions.quietDeps` to `true`
- Default set `babel.jsxRuntime` to `true`